### PR TITLE
Fix The checkbox for the 'Miscellaneous Settings' setting is not checked immediately after saving.

### DIFF
--- a/src/wpt-functions.php
+++ b/src/wpt-functions.php
@@ -36,7 +36,7 @@ function wpt_checkbox( $field, $sub1 = false, $sub2 = '' ) {
 			return 'checked="checked"';
 		}
 	}
-	if ( '1' === get_option( $field ) ) {
+	if ( 1 === (int) get_option( $field ) ) {
 		return 'checked="checked"';
 	}
 


### PR DESCRIPTION
## Description

The checkbox for the "Miscellaneous Settings" setting is not checked immediately after saving.

Inputting
![1](https://github.com/joedolson/wp-to-twitter/assets/2771396/ca45bec3-5f6d-495d-931b-7a84afa439de)

After saved
![2](https://github.com/joedolson/wp-to-twitter/assets/2771396/40644199-6855-4b00-924e-23db6ca0ed50)

It is checked correctly when I reload the page.

## How Has This Been Tested?

I performed the following tests on those checkboxes.

- Checked state: Value is saved in option and display is also checked
- Unchecked state: Value is saved in option and display is not checked

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code is backward-compatible with WordPress 4.9 and PHP 7.0.
- [x] My code follows the WordPress coding standards.
- [x] My code has proper inline documentation.
